### PR TITLE
Add voila

### DIFF
--- a/env/dev/values.yaml
+++ b/env/dev/values.yaml
@@ -2,6 +2,16 @@
 redirect:
   enabled: false
 
+voila:
+  enabled: true
+  ingress:
+    hosts:
+    - voila-dev.pangeo.informaticslab.co.uk
+    tls:
+      - hosts:
+        - voila-dev.pangeo.informaticslab.co.uk
+        secretName: kubelego-tls-voila-pangeo-dev.informaticslab.co.uk
+
 pangeo:
   jupyterhub:
     ingress:

--- a/env/prod/values.yaml
+++ b/env/prod/values.yaml
@@ -6,7 +6,7 @@ redirect:
   - 'jupyter.informaticslab.co.uk'
 
 pangeo:
-  jupyterhub:    
+  jupyterhub:
     ingress:
       hosts:
       - pangeo.informaticslab.co.uk

--- a/jadepangeo/templates/voila-deployment.yaml
+++ b/jadepangeo/templates/voila-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: redirect
+  name: voila
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: voila

--- a/jadepangeo/templates/voila-deployment.yaml
+++ b/jadepangeo/templates/voila-deployment.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.voila.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redirect
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: voila
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: voila
+        component: voila
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+    spec:
+      containers:
+        - name: voila
+          image: {{ .Values.pangeo.jupyterhub.singleuser.image.name }}:{{ .Values.pangeo.jupyterhub.singleuser.image.tag }}
+          args: [voila, /scratch/voila]
+          resources:
+            cpu:
+              limit: {{ .Values.voila.resources.cpu.limit }}
+              guarantee: {{ .Values.voila.resources.cpu.guarantee }}
+            memory:
+              limit: {{ .Values.voila.resources.memory.limit }}
+              guarantee: {{ .Values.voila.resources.memory.guarantee }}
+          volumeMounts:
+            - name: s3
+              mountPath: /s3
+            - name: scratch
+              mountPath: /scratch
+          nodeSelector:
+            k8s.io/cluster-autoscaler/node-template/label/spot: "true"
+          ports:
+            - name: voila
+              containerPort: 8866
+      volumes:
+        - name: s3
+          flexVolume:
+            driver: "informaticslab/pysssix-flex-volume"
+            options:
+              readonly: "true"
+        - name: scratch
+          flexVolume:
+            driver: "informaticslab/goofys-flex-volume"
+            options:
+              bucket: "informatics-pangeo-scratch"
+              dirMode: "0777"
+              fileMode: "0777"
+{{- end -}}

--- a/jadepangeo/templates/voila-ingress.yaml
+++ b/jadepangeo/templates/voila-ingress.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.voila.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: voila
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    {{- range $host := .Values.voila.ingress.hosts }}
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: voila
+              servicePort: 80
+    {{- end }}
+  {{- if .Values.voila.ingress.tls }}
+  tls:
+    {{- .Values.voila.ingress.tls | toYaml | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/jadepangeo/templates/voila-service.yaml
+++ b/jadepangeo/templates/voila-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.voila.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: voila
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: voila
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    name: voila
+    component: voila
+    release: {{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: voila
+{{- end -}}

--- a/jadepangeo/values.yaml
+++ b/jadepangeo/values.yaml
@@ -32,7 +32,7 @@ pangeo:
 
           c.KubeSpawner.profile_list = [
             {
-              'display_name': 'Informatics Lab - Pangeo Notebook v0.5.10 (recomended)',
+              'display_name': 'Informatics Lab - Pangeo Notebook v0.5.11 (recomended)',
               'kubespawner_override': {'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.5.11'},
               'default': True
             },{

--- a/jadepangeo/values.yaml
+++ b/jadepangeo/values.yaml
@@ -6,6 +6,16 @@ telegraf:
 redirect:
   enabled: false
 
+voila:
+  enabled: false
+  resources:
+    cpu:
+      limit: 2
+      guarantee: 1
+    memory:
+      limit: 16G
+      guarantee: 2G
+
 pangeo:
   jupyterhub:
 

--- a/jadepangeo/values.yaml
+++ b/jadepangeo/values.yaml
@@ -42,8 +42,8 @@ pangeo:
 
           c.KubeSpawner.profile_list = [
             {
-              'display_name': 'Informatics Lab - Pangeo Notebook v0.5.11 (recomended)',
-              'kubespawner_override': {'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.5.11'},
+              'display_name': 'Informatics Lab - Pangeo Notebook v0.5.14 (recomended)',
+              'kubespawner_override': {'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.5.14'},
               'default': True
             },{
               'display_name': 'Informatics Lab - Pangeo Notebook dev (unstable)',
@@ -81,7 +81,7 @@ pangeo:
     singleuser:
       image:
         name: 536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook
-        tag: '0.5.11'
+        tag: '0.5.14'
       cmd: jupyter-labhub
       defaultUrl: "/lab"
       cpu:


### PR DESCRIPTION
This PR adds [voila](https://github.com/QuantStack/voila) support.

Voila is an interactive notebook server which allows people to safely run published notebooks.

This adds a voila service, networking and configuration and access to shared notebooks. Any notebooks placed in `/scratch/voila` will become available through voila.

For now it is just being enabled on dev at voila-dev.pangeo.informaticslab.co.uk.