### PR TITLE
Bump image to 0.6.1

### DIFF
--- a/jadepangeo/values.yaml
+++ b/jadepangeo/values.yaml
@@ -42,8 +42,8 @@ pangeo:
 
           c.KubeSpawner.profile_list = [
             {
-              'display_name': 'Informatics Lab - Pangeo Notebook v0.5.21 (recomended)',
-              'kubespawner_override': {'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.5.21'},
+              'display_name': 'Informatics Lab - Pangeo Notebook v0.6.1 (recomended)',
+              'kubespawner_override': {'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.6.1'},
               'default': True
             },
             {
@@ -54,16 +54,23 @@ pangeo:
               }
             },
             {
-              'display_name': 'Informatics Lab - ML Notebook v0.5.21 (unstable)',
+              'display_name': 'Informatics Lab - ML Notebook v0.6.1 (unstable)',
               'kubespawner_override': {
-                'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.5.21',
+                'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.6.1',
                 'cpu_limit': 7,
                 'mem_limit': '28G',
                 },
-            },{
+            },
+            {
+              'display_name': 'Informatics Lab - Pangeo Notebook v0.5.21',
+              'kubespawner_override': {'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.5.21'},
+              'default': True
+            },
+            {
               'display_name': 'Informatics Lab - Pangeo Notebook v0.5.4',
               'kubespawner_override': {'singleuser_image_spec': 'informaticslab/pangeo-notebook:0.5.4'}
-            },{
+            },
+            {
               'display_name': 'Pangeo - Pangeo Notebook',
               'kubespawner_override': {'singleuser_image_spec': 'pangeo/notebook:2018-06-13.4'}
             }]
@@ -90,7 +97,7 @@ pangeo:
     singleuser:
       image:
         name: 536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook
-        tag: '0.5.21'
+        tag: '0.6.1'
       cmd: jupyter-labhub
       defaultUrl: "/lab"
       cpu:


### PR DESCRIPTION
Switching the default docker image to the new 0.6.x release track. Leaving 0.5.21 as an available image just in case.