### PR TITLE
Remove 0.5.x image duplication of 'default' option

### DIFF
--- a/jadepangeo/values.yaml
+++ b/jadepangeo/values.yaml
@@ -62,8 +62,8 @@ pangeo:
                 },
             },
             {
-              'display_name': 'Informatics Lab - Pangeo Notebook v0.5.24',
-              'kubespawner_override': {'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.5.24'}
+              'display_name': 'Informatics Lab - Pangeo Notebook v0.5.25',
+              'kubespawner_override': {'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.5.25'}
             },
             {
               'display_name': 'Informatics Lab - Pangeo Notebook v0.5.4',

--- a/jadepangeo/values.yaml
+++ b/jadepangeo/values.yaml
@@ -63,8 +63,7 @@ pangeo:
             },
             {
               'display_name': 'Informatics Lab - Pangeo Notebook v0.5.24',
-              'kubespawner_override': {'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.5.24'},
-              'default': True
+              'kubespawner_override': {'singleuser_image_spec': '536099501702.dkr.ecr.eu-west-2.amazonaws.com/pangeo-notebook:0.5.24'}
             },
             {
               'display_name': 'Informatics Lab - Pangeo Notebook v0.5.4',


### PR DESCRIPTION
This should prevent 0.5.x image from being pre-selected on the image picker list rather than the 0.6.x image as we want.